### PR TITLE
FIX: Not working on WP8.1 Update 2 and Pebble Firmware v2.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To use the library with Windows Phone 8.1 and WinRT (WinRT not finished currentl
 ```
     <m2:DeviceCapability Name="bluetooth.rfcomm">
       <m2:Device Id="any">
-        <m2:Function Type="serviceId:00001101-0000-1000-8000-00805F9B34FB"/>
+        <m2:Function Type="serviceId:00000000-deca-fade-deca-deafdecacaff"/>
       </m2:Device>
     </m2:DeviceCapability>
 ```

--- a/src/P3bble.Core/Communication/Protocol.cs
+++ b/src/P3bble.Core/Communication/Protocol.cs
@@ -54,8 +54,9 @@ namespace P3bble.Communication
         {
 #if WINDOWS_PHONE || WINDOWS_PHONE_APP
             // {00001101-0000-1000-8000-00805f9b34fb} specifies we want a Serial Port - see http://developer.nokia.com/Community/Wiki/Bluetooth_Services_for_Windows_Phone
+            // {00000000-deca-fade-deca-deafdecacaff} Fix ServiceID for WP8.1 Update 2
             StreamSocket socket = new StreamSocket();
-            await socket.ConnectAsync(peer.HostName, new Guid(0x00001101, 0x0000, 0x1000, 0x80, 0x00, 0x00, 0x80, 0x5F, 0x9B, 0x34, 0xFB).ToString("B"));
+            await socket.ConnectAsync(peer.HostName, Guid.Parse("00000000-deca-fade-deca-deafdecacaff").ToString("B"));
             return new Protocol(socket);
 #endif
 

--- a/src/Samples/P3bble-8.1/Package.appxmanifest
+++ b/src/Samples/P3bble-8.1/Package.appxmanifest
@@ -31,7 +31,7 @@
 
     <m2:DeviceCapability Name="bluetooth.rfcomm">
       <m2:Device Id="any">
-        <m2:Function Type="serviceId:00001101-0000-1000-8000-00805F9B34FB"/>
+        <m2:Function Type="serviceId:00000000-deca-fade-deca-deafdecacaff"/>
       </m2:Device>
     </m2:DeviceCapability>
   </Capabilities>


### PR DESCRIPTION
The current version wasn't working because of the given ServiceID, using the new one seems to fix the communication.

Solution found by @rut4

Cheers.
